### PR TITLE
Add an option for a wireshark "Copy as Hex Stream" input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Differences in this fork:
 
 * Add support for parsing array notation (`[1, 2, 254, 255]`)
 * Add support for parsing hexarray notation (`[01, 02, fe, ff]`)
+* Add support for parsing data copied from Wireshark with "Copy Bytes as a Hex
+Stream" (`0102feff`)
 * Load initial data from hash parameter (`#base64=<data>` or `#array=<data>`)
 * Extract stylesheets and scripts from index.html into separate files
 * Some CSS tweaks

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
                         <option value="base64" selected>Base64:</option>
                         <option value="array">Array:</option>
                         <option value="hexarray">Hex Array:</option>
+                        <option value="ws_hexstream">WireShark Hex Stream:</option>
                     </select>
                     <input type="text" id="data" style="width:60vw" value="gaVoZWxsb6V3b3JsZA==" />
                     <button type="submit">Parse</button>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -353,6 +353,9 @@ function parseInput() {
         case "hexarray":
             parseHexarray(data);
             break;
+        case "ws_hexstream":
+            parseWSHexStream(data);
+            break;
         default:
             alert("Invalid input type: " + inputType);
     }
@@ -414,6 +417,28 @@ function parseHexarray(data) {
         e.stack && errlog(e.stack);
     }
 }
+
+/**
+ * Parse the input as a WireShark Hex stream.
+ * Example: 0102feff
+ */
+function parseWSHexStream(data) {
+    try {
+        const trimmed = data.trim();
+        const inner = trimmed;
+        const numbers = inner
+            .match(/.{1,2}/g)
+            .map(n => n.trim())
+            .map(n => parseInt(n, 16));
+        const u8array = new Uint8Array(numbers);
+        const dataView = new DataView(u8array.buffer);
+        showParsedData(dataView);
+    } catch (e) {
+        errlog("Error parsing input: " + e.message);
+        e.stack && errlog(e.stack);
+    }
+}
+
 
 /**
  * Show the parsed data on the page.


### PR DESCRIPTION
This allows parsing data directly copied from wireshark by right-clicking on the data and copying with the "Copy Bytes as a Hex Stream" option.