### PR TITLE
Improvements on the visualization of big messagepack structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Differences in this fork:
 
 * Add support for parsing array notation (`[1, 2, 254, 255]`)
 * Add support for parsing hexarray notation (`[01, 02, fe, ff]`)
+* Add support for parsing data copied from Wireshark with "Copy Bytes as a Hex
+Stream" (`0102feff`)
 * Load initial data from hash parameter (`#base64=<data>` or `#array=<data>`)
 * Extract stylesheets and scripts from index.html into separate files
 * Some CSS tweaks

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/css/style.css
+++ b/css/style.css
@@ -21,6 +21,12 @@ html, body {
     padding: 0;
 }
 
+.poslink {
+    display: inline-block;
+    width: 150px;
+    text-align: right;
+}
+
 #output-wrapper {
     display: flex;
     flex-flow: row;

--- a/css/style.css
+++ b/css/style.css
@@ -12,15 +12,26 @@ body {
     padding: 8px;
     font-family: sans-serif;
     display: flex;
-    flex-direction: column;
-    height: 98%;
-}
-html, body, #content, #output-wrapper {
+    flex-flow: column;
     height: 100%;
+}
+html, body {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+}
+
+#output-wrapper {
+    display: flex;
+    flex-flow: row;
+    flex: 0 1 auto;
 }
 h1 {
     font-size: 48px;
     margin-bottom: 16px;
+}
+#header {
+    flex: 0 1 auto;
 }
 #header p {
     font-size: 16px;
@@ -30,22 +41,25 @@ h1 {
     margin-top: 8px;
     margin-bottom: 16px;
 }
+#content {
+    display: flex;
+    flex-flow: column;
+    flex: 0 1 auto;
+    height: 100%;
+}
 #output-wrapper {
     display: flex;
-    flex-direction: row;
+    flex-flow: row;
+    flex: 1 1 auto;
 }
 #datadisplay {
-    width: 390px;
     border-right: 2px solid #aaa;
     font-family: monospace;
     vertical-align: top;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    align-content: flex-start;
     overflow-y: auto;
-    height: 100%;
+    min-height: 100%;
+    height: 0;
+    flex: 0 1 25%;
 }
 #datadisplay a {
     display: inline-block;
@@ -63,7 +77,9 @@ h1 {
     flex-grow: 1;
     padding-left: 8px;
     overflow-y: auto;
-    height: 100%;
+    min-height: 100%;
+    height: 0;
+    flex: 0 1 75%;
 }
 #json-obj {
     word-break: break-all;

--- a/css/style.css
+++ b/css/style.css
@@ -13,6 +13,10 @@ body {
     font-family: sans-serif;
     display: flex;
     flex-direction: column;
+    height: 98%;
+}
+html, body, #content, #output-wrapper {
+    height: 100%;
 }
 h1 {
     font-size: 48px;
@@ -40,6 +44,8 @@ h1 {
     flex-wrap: wrap;
     justify-content: flex-start;
     align-content: flex-start;
+    overflow-y: auto;
+    height: 100%;
 }
 #datadisplay a {
     display: inline-block;
@@ -56,6 +62,8 @@ h1 {
 #output {
     flex-grow: 1;
     padding-left: 8px;
+    overflow-y: auto;
+    height: 100%;
 }
 #json-obj {
     word-break: break-all;

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
                         <option value="base64" selected>Base64:</option>
                         <option value="array">Array:</option>
                         <option value="hexarray">Hex Array:</option>
+                        <option value="ws_hexstream">WireShark Hex Stream:</option>
                     </select>
                     <input type="text" id="data" style="width:60vw" value="gaVoZWxsb6V3b3JsZA==" />
                     <button type="submit">Parse</button>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -44,6 +44,16 @@ function log(position, length, str) {
     span.innerHTML = ": " + str;
     div.appendChild(span);
     logoutput.appendChild(div);
+    return div; // Return the created element in case it needs to be modified
+}
+
+function logedit(div, position, length, str) {
+    var a = div.children[0];
+    var span = div.children[1];
+
+    a.rel = position + "," + length;
+    a.innerHTML = "position " + position;
+    span.innerHTML = ": " + str;
 }
 
 function clear() {
@@ -123,159 +133,165 @@ function decode(dataView) {
         var value, length;
         switch (type) {
             // nil
-        case 0xc0:
-            log(offset, 1, "NULL");
-            offset++;
-            return null;
+            case 0xc0:
+                log(offset, 1, "NULL");
+                offset++;
+                return null;
             // false
-        case 0xc2:
-            log(offset, 1, "false");
-            offset++;
-            return false;
+            case 0xc2:
+                log(offset, 1, "false");
+                offset++;
+                return false;
             // true
-        case 0xc3:
-            log(offset, 1, "true");
-            offset++;
-            return true;
+            case 0xc3:
+                log(offset, 1, "true");
+                offset++;
+                return true;
             // bin 8
-        case 0xc4:
-            length = dataView.getUint8(offset + 1);
-            var startOffset = offset;
-            offset += 2;
-            var result = raw(length);
-            log(startOffset, offset - startOffset, "<a href='" + SPEC + "#bin-format-family'>bin8 marker with " + length + " items");
-            return result;
+            case 0xc4:
+                length = dataView.getUint8(offset + 1);
+                var startOffset = offset;
+                offset += 2;
+                var result = raw(length);
+                log(startOffset, offset - startOffset, "<a href='" + SPEC + "#bin-format-family'>bin8 marker with " + length + " items");
+                return result;
             // bin 16
-        case 0xc5:
-            length = dataView.getUint16(offset + 1);
-            var startOffset = offset;
-            offset += 3;
-            var result = raw(length);
-            log(startOffset, offset - startOffset, "<a href='" + SPEC + "#bin-format-family'>bin16 marker with " + length + " items");
-            return result;
+            case 0xc5:
+                length = dataView.getUint16(offset + 1);
+                var startOffset = offset;
+                offset += 3;
+                var result = raw(length);
+                log(startOffset, offset - startOffset, "<a href='" + SPEC + "#bin-format-family'>bin16 marker with " + length + " items");
+                return result;
             // bin 32
-        case 0xc6:
-            length = dataView.getUint32(offset + 1);
-            var startOffset = offset;
-            offset += 5;
-            var result = raw(length);
-            log(startOffset, offset - startOffset, "<a href='" + SPEC + "#bin-format-family'>bin32 marker with " + length + " items");
-            return result;
+            case 0xc6:
+                length = dataView.getUint32(offset + 1);
+                var startOffset = offset;
+                offset += 5;
+                var result = raw(length);
+                log(startOffset, offset - startOffset, "<a href='" + SPEC + "#bin-format-family'>bin32 marker with " + length + " items");
+                return result;
             // float
-        case 0xca:
-            value = dataView.getFloat32(offset + 1);
-            log(offset, 5, "float value " + value);
-            offset += 5;
-            return value;
+            case 0xca:
+                value = dataView.getFloat32(offset + 1);
+                log(offset, 5, "float value " + value);
+                offset += 5;
+                return value;
             // double
-        case 0xcb:
-            value = dataView.getFloat64(offset + 1);
-            log(offset, 9, "double value " + value);
-            offset += 9;
-            return value;
+            case 0xcb:
+                value = dataView.getFloat64(offset + 1);
+                log(offset, 9, "double value " + value);
+                offset += 9;
+                return value;
             // uint8
-        case 0xcc:
-            value = dataView.getUint8(offset + 1);
-            log(offset, 2, "uint8 value " + value);
-            offset += 2;
-            return value;
+            case 0xcc:
+                value = dataView.getUint8(offset + 1);
+                log(offset, 2, "uint8 value " + value);
+                offset += 2;
+                return value;
             // uint 16
-        case 0xcd:
-            value = dataView.getUint16(offset + 1);
-            log(offset, 3, "uint16 value " + value);
-            offset += 3;
-            return value;
+            case 0xcd:
+                value = dataView.getUint16(offset + 1);
+                log(offset, 3, "uint16 value " + value);
+                offset += 3;
+                return value;
             // uint 32
-        case 0xce:
-            value = dataView.getUint32(offset + 1);
-            log(offset, 5, "uint32 value " + value);
-            offset += 5;
-            return value;
+            case 0xce:
+                value = dataView.getUint32(offset + 1);
+                log(offset, 5, "uint32 value " + value);
+                offset += 5;
+                return value;
             // uint64
-        case 0xcf:
-            // value = buffer.readUInt64BE(offset + 1);
-            log(offset, 9, "uint64 marker - cannot parse uint64 to javascript, setting to Infinity");
-            offset += 9;
-            return Infinity;
+            case 0xcf:
+                // value = buffer.readUInt64BE(offset + 1);
+                log(offset, 9, "uint64 marker - cannot parse uint64 to javascript, setting to Infinity");
+                offset += 9;
+                return Infinity;
             // int 8
-        case 0xd0:
-            value = dataView.getInt8(offset + 1);
-            log(offset, 2, "int8 value " + value);
-            offset += 2;
-            return value;
+            case 0xd0:
+                value = dataView.getInt8(offset + 1);
+                log(offset, 2, "int8 value " + value);
+                offset += 2;
+                return value;
             // int 16
-        case 0xd1:
-            value = dataView.getInt16(offset + 1);
-            log(offset, 3, "int16 value " + value);
-            offset += 3;
-            return value;
+            case 0xd1:
+                value = dataView.getInt16(offset + 1);
+                log(offset, 3, "int16 value " + value);
+                offset += 3;
+                return value;
             // int 32
-        case 0xd2:
-            value = dataView.getInt32(offset + 1);
-            log(offset, 5, "int32 value " + value);
-            offset += 5;
-            return value;
+            case 0xd2:
+                value = dataView.getInt32(offset + 1);
+                log(offset, 5, "int32 value " + value);
+                offset += 5;
+                return value;
             // int 64
-        case 0xd3:
-            log(offset, 9, "int64 marker - cannot parse uint64 to javascript, setting to Infinity");
-            offset += 9;
-            return Infinity;
+            case 0xd3:
+                log(offset, 9, "int64 marker - cannot parse uint64 to javascript, setting to Infinity");
+                offset += 9;
+                return Infinity;
             // map 16
-        case 0xde:
-            length = dataView.getUint16(offset + 1);
-            var startOffset = offset;
-            offset += 3;
-            var result = map(length);
-            log(startOffset, offset - startOffset, "<a href='" + SPEC + "#map-format-family'>map16 marker with " + length + " items");
-            return result;
+            case 0xde:
+
+                length = dataView.getUint16(offset + 1);
+
+                var startOffset = offset;
+                offset += 3;
+                var parent = log(startOffset, offset - startOffset, "placeholder");
+                var result = map(length);
+                logedit(parent, startOffset, offset - startOffset, "<a href='" + SPEC + "#map-format-family'>map16 marker with " + length + " items");
+                return result;
             // map 32
-        case 0xdf:
-            length = dataView.getUint32(offset + 1);
-            var startOffset = offset;
-            offset += 5;
-            var result = map(length);
-            log(startOffset, offset - startOffset, "<a href='" + SPEC + "#map-format-family'>map323232323232th " + length + " items");
-            return result;
+            case 0xdf:
+                length = dataView.getUint32(offset + 1);
+                var startOffset = offset;
+                offset += 5;
+                var parent = log(startOffset, offset - startOffset, "placeholder");
+                var result = map(length);
+                logedit(parent, startOffset, offset - startOffset, "<a href='" + SPEC + "#map-format-family'>map32 marker with " + length + " items")
+                return result;
             // array 16
-        case 0xdc:
-            length = dataView.getUint16(offset + 1);
-            var startOffset = offset;
-            offset += 3;
-            var result = array(length);
-            log(startOffset, offset - startOffset, "<a href='" + SPEC + "#array-format-family'>array16 marker with " + length + " items");
-            return result;
+            case 0xdc:
+                length = dataView.getUint16(offset + 1);
+                var startOffset = offset;
+                offset += 3;
+                var parent = log(startOffset, offset - startOffset, "<a href='" + SPEC + "placeholder");
+                var result = array(length);
+                logedit(parent, startOffset, offset - startOffset, "<a href='" + SPEC + "#array-format-family'>array16 marker with " + length + " items");
+                return result;
             // array 32
-        case 0xdd:
-            length = dataView.getUint32(offset + 1);
-            var startOffset = offset;
-            offset += 5;
-            var result = array(length);
-            log(startOffset, offset - startOffset, "<a href='" + SPEC + "#array-format-family'>array32 marker with " + length + " items");
-            return result;
+            case 0xdd:
+                length = dataView.getUint32(offset + 1);
+                var startOffset = offset;
+                offset += 5;
+                var parent = log(startOffset, offset - startOffset, "placeholder");
+                var result = array(length);
+                logedit(parent, startOffset, offset - startOffset, "<a href='" + SPEC + "#array-format-family'>array32 marker with " + length + " items");
+                return result;
             // raw 8
-        case 0xd9:
-            length = dataView.getUint8(offset + 1);
-            var startOffset = offset;
-            offset += 2;
-            var result = raw(length);
-            log(startOffset, offset - startOffset, "raw8 marker - " + result);
-            return result;
+            case 0xd9:
+                length = dataView.getUint8(offset + 1);
+                var startOffset = offset;
+                offset += 2;
+                var result = raw(length);
+                log(startOffset, offset - startOffset, "raw8 marker - " + result);
+                return result;
             // raw 16
-        case 0xda:
-            length = dataView.getUint16(offset + 1);
-            var startOffset = offset;
-            offset += 3;
-            var result = raw(length);
-            log(startOffset, offset - startOffset, "raw16 marker - " + result);
-            return result;
+            case 0xda:
+                length = dataView.getUint16(offset + 1);
+                var startOffset = offset;
+                offset += 3;
+                var result = raw(length);
+                log(startOffset, offset - startOffset, "raw16 marker - " + result);
+                return result;
             // raw 32
-        case 0xdb:
-            length = dataView.getUint32(offset + 1);
-            var startOffset = offset;
-            offset += 5;
-            var result = raw(length);
-            log(startOffset, offset - startOffset, "raw32 marker - " + result);
-            return result;
+            case 0xdb:
+                length = dataView.getUint32(offset + 1);
+                var startOffset = offset;
+                offset += 5;
+                var result = raw(length);
+                log(startOffset, offset - startOffset, "raw32 marker - " + result);
+                return result;
         }
         // FixRaw
         if ((type & 0xe0) === 0xa0) {
@@ -291,8 +307,9 @@ function decode(dataView) {
             length = type & 0x0f;
             var startOffset = offset;
             offset++;
+            var parent = log(startOffset, offset - startOffset, "placeholder");
             var result = map(length);
-            log(startOffset, offset - startOffset, "<a href='" + SPEC + "#map-format-family'>fixed length map</a> marker with " + length + " items");
+            logedit(parent, startOffset, offset - startOffset, "<a href='" + SPEC + "#map-format-family'>fixed length map</a> marker with " + length + " items");
             return result;
         }
         // FixArray
@@ -300,8 +317,9 @@ function decode(dataView) {
             length = type & 0x0f;
             var startOffset = offset;
             offset++;
+            var parent = log(startOffset, offset - startOffset, "<a href='" + SPEC + "#array-format-family'>fixed length array</a> marker with " + length + " items");
             var result = array(length);
-            log(startOffset, offset - startOffset, "<a href='" + SPEC + "#array-format-family'>fixed length array</a> marker with " + length + " items");
+            logedit(parent, startOffset, offset - startOffset, "<a href='" + SPEC + "#array-format-family'>fixed length array</a> marker with " + length + " items");
             return result;
         }
         // Positive FixNum

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -108,8 +108,8 @@ function decode(dataView) {
     function map(length) {
         var value = {};
         for (var i = 0; i < length; i++) {
-            var key = parse();
-            value[key] = parse();
+            var key = parse("key: ");
+            value[key] = parse("value: ");
         }
         return value;
     }
@@ -123,14 +123,32 @@ function decode(dataView) {
     function array(length) {
         var value = new Array(length);
         for (var i = 0; i < length; i++) {
-            value[i] = parse();
+            value[i] = parse("arr_idx " + i.toString() + ": ");
         }
         return value;
     }
 
-    function parse() {
+    var extlog = log;
+    var extlogedit = logedit;
+
+    function parse(logprefix) {
         var type = dataView.getUint8(offset);
         var value, length;
+
+        function log(position, length, str) {
+            if (!logprefix) {
+                logprefix = "";
+            }
+            return extlog(position, length, logprefix + str);
+        };
+
+        function logedit(div, position, length, str) {
+            if (!logprefix) {
+                logprefix = "";
+            }
+            return extlogedit(div, position, length, logprefix + str);
+        }
+
         switch (type) {
             // nil
             case 0xc0:

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -393,7 +393,7 @@ function parseArray(data) {
 
 /**
  * Parse the input as hex array.
- * Example: [01, 02, fe, ff]
+ * Example: [01, 02, fe, ff] (separator can be commas and/or space)
  */
 function parseHexarray(data) {
     try {
@@ -406,7 +406,7 @@ function parseHexarray(data) {
         }
         const inner = trimmed.substr(1, trimmed.length - 2);
         const numbers = inner
-            .split(",")
+            .split(/[\s,]+/)
             .map(n => n.trim())
             .map(n => parseInt(n, 16));
         const u8array = new Uint8Array(numbers);

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -353,6 +353,9 @@ function parseInput() {
         case "hexarray":
             parseHexarray(data);
             break;
+        case "ws_hexstream":
+            parseWSHexStream(data);
+            break;
         default:
             alert("Invalid input type: " + inputType);
     }
@@ -414,6 +417,28 @@ function parseHexarray(data) {
         e.stack && errlog(e.stack);
     }
 }
+
+/**
+ * Parse the input as a WireShark Hex stream.
+ * Example: 0102feff
+ */
+function parseWSHexStream(data) {
+    try {
+        const trimmed = data.trim();
+        const inner = trimmed;
+        const numbers = inner
+            .match(/.{1,2}/g)
+            .map(n => n.trim())
+            .map(n => parseInt(n, 16));
+        const u8array = new Uint8Array(numbers);
+        const dataView = new DataView(u8array.buffer);
+        showParsedData(dataView);
+    } catch (e) {
+        errlog("Error parsing input: " + e.message);
+        e.stack && errlog(e.stack);
+    }
+}
+
 
 /**
  * Show the parsed data on the page.


### PR DESCRIPTION
I've done some improvements to better visualize and analyze badly formed and large msgpack streams.

* Make indentation levels visible
* Indication for array element indexes
* Indication for keys and values of maps
* Improve the layout of the log and data windows, each with it's own scrollbar in case of overflow.
* Allow space as array item separator for big hex arrays captured from external sources.